### PR TITLE
Convert the golden ratio value to a private constant.

### DIFF
--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -14,9 +14,12 @@
 
 ;;; Code:
 
+(defconst -golden-ratio-value 1.6818
+  "The golden ratio constant itself")
+
 (defun -golden-ratio-dimensions ()
-  (let* ((main-rows     (floor (/ (frame-height) 1.618)))
-         (main-columns  (floor (/ (frame-width)  1.618))))
+  (let* ((main-rows     (floor (/ (frame-height) -golden-ratio-value)))
+         (main-columns  (floor (/ (frame-width)  -golden-ratio-value))))
     (list main-rows
           main-columns)))
 


### PR DESCRIPTION
Changed the numeric value by a private constant in the code.
