### PR TITLE
Fix MELPA footer

### DIFF
--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -72,4 +72,4 @@
 
 (provide 'golden-ratio)
 
-;;; filename ends here
+;;; golden-ratio.el ends here


### PR DESCRIPTION
[MELPA](http://melpa.milkbox.net/) expects single file packages to be of the form,

``` lisp
;;; <name>.el --- <description>

<file contents>

;;; <name>.el ends here
```

This small patch amends the footer to bring it in line with this convention. For more information, see the [docs for marmalade-package](http://marmalade-repo.org/doc-files/package.5.html).
