### PR TITLE
scaling of width for wide frames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,31 @@ If you want to disable automatic resizing done by golden-ratio, just invoke
 
 To call golden ratio manually just `M-x golden-ratio`
 
-If you use a large screen and have very wide frames, setting the golden-ratio-adjust-width
+***
+
+If you use a large screen and have very wide frames, setting the _golden-ratio-adjust-factor_
 variable to something less than 1 will cause the windows to be less wide.
 The golden-ratio-adjust function allows for experimentation with this value.
 
 `M-x golden-ratio-adjust` 
+
+It is also possible to toggle between widescreen and regular width window sizing
+with
+
+`M-x golden-ratio-toggle-widescreen`
+
+The variable _golden-ratio-wide-adjust-factor_ can be set to the adjustment value 
+you desire the widescreen toggle to use.
+
+The following code will set up golden-ratio to adjust for a moderately wide screen
+and also allow toggling between normal, with an adjustment factor of 1, and wide with
+an adjustment factor of .8. For a very wide screen/frame of ~3400 px, .4 works well giving
+screens with a width ~100 columns wide.
+
+```elisp
+(setq golden-ratio-adjust-factor .8
+      golden-ratio-wide-adjust-factor .8)
+```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,18 @@ To call golden ratio manually just `M-x golden-ratio`
 
 ## Wide Screens
 
-If you use a large screen and have very wide frames, setting the _golden-ratio-adjust-factor_
-variable to something less than 1 will cause the windows to be less wide.
+If you use a large screen and have very wide frames golden-ratio makes very 
+wide windows. This can be handled automatically by setting _golden-ratio-auto-scale_
+to true. This does a good job of keeping windows at a reasonable width regardless of
+how wide or narrow your frame size is. This works well on my laptop regardless of
+which monitor or LCD I happen to be using.
+
+`(setq golden-ratio-auto-scale t)` 
+
+For those who wish for manual control,
+If _golden-ratio-auto-scale_ is false, manual control can be exercised
+through the _golden-ratio-adjust-factor_ variable.
+setting it to something less than 1 will cause the windows to be less wide.
 The golden-ratio-adjust function allows for experimentation with this value.
 
 `M-x golden-ratio-adjust` 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you want to disable automatic resizing done by golden-ratio, just invoke
 
 To call golden ratio manually just `M-x golden-ratio`
 
-***
+## Wide Screens
 
 If you use a large screen and have very wide frames, setting the _golden-ratio-adjust-factor_
 variable to something less than 1 will cause the windows to be less wide.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ If you want to disable automatic resizing done by golden-ratio, just invoke
 
 To call golden ratio manually just `M-x golden-ratio`
 
+If you use a large screen and have very wide frames, setting the golden-ratio-adjust-width
+variable to something less than 1 will cause the windows to be less wide.
+The golden-ratio-adjust function allows for experimentation with this value.
+
+`M-x golden-ratio-adjust` 
+
 ## Credits
 
 Code inspired by ideas from [Tatsuhiro Ujihisa](http://twitter.com/ujm)

--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -74,6 +74,13 @@ will not cause the window to be resized to the golden ratio."
   :group 'golden-ratio
   :type 'float)
 
+(defcustom golden-ratio-auto-scale f
+  "Automatic width adjustment factoring. Scales the width
+   of the screens to be smaller as the frame gets bigger."
+  :group 'golden-ratio
+  :type 'boolean)
+
+
 ;;; Compatibility
 ;;
 (unless (fboundp 'window-resizable-p)
@@ -94,10 +101,15 @@ will not cause the window to be resized to the golden ratio."
   (setq golden-ratio-adjust-factor a)
   (golden-ratio))
 
+(defun golden-ratio--scale-factor ()
+  (if golden-ratio-auto-scale
+      (- 1.0 (* (/ (- (frame-width) 100.0) 1000.0) 1.8))
+    golden-ratio-adjust-factor))
+
 (defun golden-ratio--dimensions ()
   (list (floor (/ (frame-height) golden-ratio--value))
         (floor  (* (/ (frame-width)  golden-ratio--value)
-                   golden-ratio-adjust-factor))))
+                   (golden-ratio--scale-factor)))))
 
 (defun golden-ratio--resize-window (dimensions &optional window)
   (with-selected-window (or window (selected-window))

--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -62,28 +62,42 @@ will not cause the window to be resized to the golden ratio."
   :group 'golden-ratio
   :type 'boolean)
 
-(defcustom golden-ratio-adjust-width 1.0
+(defcustom golden-ratio-adjust-factor 1.0
   "Adjust the width sizing by some factor. 1 is no adjustment.
-   For very wide screens/frames .4 may work well."
+   For very wide screens/frames, ie. 3400px, .4 may work well."
   :group 'golden-ratio
   :type 'integer)
+
+(defcustom golden-ratio-wide-adjust-factor 0.8
+  "Width adjustment factor for widescreens. Used when
+   toggling between widescreen and regular modes."
+  :group 'golden-ratio
+  :type 'float)
 
 ;;; Compatibility
 ;;
 (unless (fboundp 'window-resizable-p)
   (defalias 'window-resizable-p 'window--resizable-p))
 
+(defun golden-ratio-toggle-widescreen ()
+  (interactive)
+  (if (= golden-ratio-adjust-factor 1)
+      (setq golden-ratio-adjust-factor golden-ratio-wide-adjust-factor)
+    (setq golden-ratio-adjust-factor 1))
+  (golden-ratio))
+
 (defun golden-ratio-adjust (a)
   "set the adjustment of window widths."
   (interactive
    (list
-    (read-number "Adjust: " golden-ratio-adjust-width)))
-  (setq golden-ratio-adjust-width a))
+    (read-number "Screeen width adjustment factor: " golden-ratio-adjust-factor)))
+  (setq golden-ratio-adjust-factor a)
+  (golden-ratio))
 
 (defun golden-ratio--dimensions ()
   (list (floor (/ (frame-height) golden-ratio--value))
         (floor  (* (/ (frame-width)  golden-ratio--value)
-                   golden-ratio-adjust-width))))
+                   golden-ratio-adjust-factor))))
 
 (defun golden-ratio--resize-window (dimensions &optional window)
   (with-selected-window (or window (selected-window))

--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -74,7 +74,7 @@ will not cause the window to be resized to the golden ratio."
   :group 'golden-ratio
   :type 'float)
 
-(defcustom golden-ratio-auto-scale f
+(defcustom golden-ratio-auto-scale nil
   "Automatic width adjustment factoring. Scales the width
    of the screens to be smaller as the frame gets bigger."
   :group 'golden-ratio

--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -62,14 +62,28 @@ will not cause the window to be resized to the golden ratio."
   :group 'golden-ratio
   :type 'boolean)
 
+(defcustom golden-ratio-adjust-width 1.0
+  "Adjust the width sizing by some factor. 1 is no adjustment.
+   For very wide screens/frames .4 may work well."
+  :group 'golden-ratio
+  :type 'integer)
+
 ;;; Compatibility
 ;;
 (unless (fboundp 'window-resizable-p)
   (defalias 'window-resizable-p 'window--resizable-p))
 
+(defun golden-ratio-adjust (a)
+  "set the adjustment of window widths."
+  (interactive
+   (list
+    (read-number "Adjust: " golden-ratio-adjust-width)))
+  (setq golden-ratio-adjust-width a))
+
 (defun golden-ratio--dimensions ()
   (list (floor (/ (frame-height) golden-ratio--value))
-        (floor (/ (frame-width)  golden-ratio--value))))
+        (floor  (* (/ (frame-width)  golden-ratio--value)
+                   golden-ratio-adjust-width))))
 
 (defun golden-ratio--resize-window (dimensions &optional window)
   (with-selected-window (or window (selected-window))


### PR DESCRIPTION
This happened in two stages. I'm not terribly attached to the first stage seeing that the second thing works so well.  But I left it because it's nice to have more control.  Basically I added two factor variables, one for when calculations are done, which can be 1 or some other value.  Another variable that can be set to something less than zero to scale the width of the windows down on wide screens.  There are two new functions, one to set the factor value used in calculations, and another to toggle between the widescreen factor value and 1.   This works pretty well but requires some user interaction.  I have to toggle the widescreen mode when I go with my laptop somewhere, and back again when I connect to my wide monitor.

Then I added a new calculation that scales according to frame-size.  This works really well for any size frame, but can cause active windows to actually shrink if there is more frame than windows.  There is an additional 
variable that allows this behavior to be turned on or off.  When off, it works as above.  

The overall default behavior has not changed.  Setting auto scaling, or the factor values or both allows for as fine control as someone might want over the scaling of window widths.