### PR TITLE
Use a common way to avoid recursion

### DIFF
--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -84,7 +84,8 @@ will not cause the window to be resized to the golden ratio."
 (defun golden-ratio ()
   "Resizes current window to the golden-ratio's size specs."
   (interactive)
-  (unless (or (window-minibuffer-p)
+  (unless (or (not golden-ratio-mode)
+              (window-minibuffer-p)
               (one-window-p)
               (member (symbol-name major-mode)
                       golden-ratio-exclude-modes)
@@ -94,15 +95,13 @@ will not cause the window to be resized to the golden ratio."
                    (loop for fun in golden-ratio-inhibit-functions
                          thereis (funcall fun))))
     (let ((dims (golden-ratio--dimensions))
-          (golden-p (if golden-ratio-mode 1 -1)))
+          (golden-ratio-mode nil))
       ;; Always disable `golden-ratio-mode' to avoid
       ;; infinite loop in `balance-windows'.
-      (golden-ratio-mode -1)
       (balance-windows)
       (golden-ratio--resize-window dims)
       (when golden-ratio-recenter
-        (scroll-right) (recenter))
-      (golden-ratio-mode golden-p))))
+        (scroll-right) (recenter)))))
 
 ;; Should return nil
 (defadvice other-window


### PR DESCRIPTION
This patch allows for comfortable temporary disabling of the `golden-ratio` function, while still avoiding recursion: `(let (golden-ratio-mode nil) do-something-with-window-here)`. Otherwise, it works as intended.

It turned out that hydra's (see https://github.com/abo-abo/hydra) uses a special echo window, and using a usual way to disable a minor mode does not work (see https://github.com/abo-abo/hydra/issues/64 for more details). Actually, the hydra project owner already had three related issues. :-)
