### PR TITLE
Simplify `golden-ratio-mode'

### DIFF
--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -27,8 +27,8 @@
 ;; Major modes that are exempt from being resized. An example of this
 ;; for users of Org-mode might be:
 ;;  ("calendar-mode")
-(defcustom golden-ratio-exclude-modes nil
-  "An array of strings naming major modes.
+(defcustom golden-ratio-exclude-modes '(ediff-mode)
+  "An array major mode symbols.
 Switching to a buffer whose major mode is a member of this list
 will not cause the window to be resized to the golden ratio."
   :type '(repeat string)
@@ -132,14 +132,13 @@ will not cause the window to be resized to the golden ratio."
     (let ((golden-ratio-in-progress t))
       (unless (or (window-minibuffer-p)
                   (one-window-p)
-                  (member (symbol-name major-mode)
-                          golden-ratio-exclude-modes)
+                  (memq major-mode golden-ratio-exclude-modes)
                   (member (buffer-name)
                           golden-ratio-exclude-buffer-names)
                   (and golden-ratio-inhibit-functions
                        (loop for fun in golden-ratio-inhibit-functions
                           thereis (funcall fun))))
-        (balance-windows)
+        ;; (balance-windows)
         (golden-ratio--resize-window (golden-ratio--dimensions))
         (when golden-ratio-recenter
           (scroll-right) (recenter))))))

--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -120,72 +120,39 @@ will not cause the window to be resized to the golden ratio."
       (when (window-resizable-p (selected-window) ncol t)
         (enlarge-window ncol t)))))
 
+(defvar golden-ratio-in-progress nil
+  "Avoid recursive adjustment.")
+
 ;;;###autoload
 (defun golden-ratio ()
   "Resizes current window to the golden-ratio's size specs."
   (interactive)
-  (unless (or (window-minibuffer-p)
-              (one-window-p)
-              (member (symbol-name major-mode)
-                      golden-ratio-exclude-modes)
-              (member (buffer-name)
-                      golden-ratio-exclude-buffer-names)
-              (and golden-ratio-inhibit-functions
-                   (loop for fun in golden-ratio-inhibit-functions
-                         thereis (funcall fun))))
-    (let ((dims (golden-ratio--dimensions))
-          (golden-p (if golden-ratio-mode 1 -1)))
-      ;; Always disable `golden-ratio-mode' to avoid
-      ;; infinite loop in `balance-windows'.
-      (golden-ratio-mode -1)
-      (balance-windows)
-      (golden-ratio--resize-window dims)
-      (when golden-ratio-recenter
-        (scroll-right) (recenter))
-      (golden-ratio-mode golden-p))))
+  (when (and golden-ratio-mode
+             (not golden-ratio-in-progress))
+    (let ((golden-ratio-in-progress t))
+      (unless (or (window-minibuffer-p)
+                  (one-window-p)
+                  (member (symbol-name major-mode)
+                          golden-ratio-exclude-modes)
+                  (member (buffer-name)
+                          golden-ratio-exclude-buffer-names)
+                  (and golden-ratio-inhibit-functions
+                       (loop for fun in golden-ratio-inhibit-functions
+                          thereis (funcall fun))))
+        (balance-windows)
+        (golden-ratio--resize-window (golden-ratio--dimensions))
+        (when golden-ratio-recenter
+          (scroll-right) (recenter))))))
 
-;; Should return nil
-(defadvice other-window
-    (after golden-ratio-resize-window)
-  (golden-ratio) nil)
-
-;; Should return the buffer
-(defadvice pop-to-buffer
-    (around golden-ratio-resize-window)
-  (prog1 ad-do-it (golden-ratio)))
-
-(defun golden-ratio--post-command-hook ()
-  (when (or (memq this-command golden-ratio-extra-commands)
-            (and (consp this-command) ; A lambda form.
-                 (loop for com in golden-ratio-extra-commands
-                       thereis (or (memq com this-command)
-                                   (memq (car-safe com) this-command)))))
-    ;; This is needed in emacs-25 to avoid this error from `recenter':
-    ;; `recenter'ing a window that does not display current-buffer.
-    ;; This doesn't happen in emacs-24.4 and previous versions.
-    (run-with-idle-timer 0.01 nil (lambda () (golden-ratio)))))
-
-(defun golden-ratio--mouse-leave-buffer-hook ()
-  (run-at-time 0.1 nil (lambda ()
-			 (golden-ratio))))
+(defadvice select-window (after golden-ratio-select-window activate)
+  (when golden-ratio-mode
+    (golden-ratio)))
 
 ;;;###autoload
 (define-minor-mode golden-ratio-mode
     "Enable automatic window resizing with golden ratio."
   :lighter " Golden"
-  :global t
-  (if golden-ratio-mode
-      (progn
-        (add-hook 'window-configuration-change-hook 'golden-ratio)
-        (add-hook 'post-command-hook 'golden-ratio--post-command-hook)
-        (add-hook 'mouse-leave-buffer-hook 'golden-ratio--mouse-leave-buffer-hook)
-        (ad-activate 'other-window)
-        (ad-activate 'pop-to-buffer))
-      (remove-hook 'window-configuration-change-hook 'golden-ratio)
-      (remove-hook 'post-command-hook 'golden-ratio--post-command-hook)
-      (remove-hook 'mouse-leave-buffer-hook 'golden-ratio--mouse-leave-buffer-hook)
-      (ad-deactivate 'other-window)
-      (ad-deactivate 'pop-to-buffer)))
+  :global t)
 
 
 (provide 'golden-ratio)

--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -115,9 +115,14 @@ will not cause the window to be resized to the golden ratio."
   (with-selected-window (or window (selected-window))
     (let ((nrow  (floor (- (first  dimensions) (window-height))))
           (ncol  (floor (- (second dimensions) (window-width)))))
-      (when (window-resizable-p (selected-window) nrow)
+      (when (and
+             (window-resizable-p (selected-window) nrow)
+             ;; don't enlarge ignored windows
+             (> nrow 0))
         (enlarge-window nrow))
-      (when (window-resizable-p (selected-window) ncol t)
+      (when (and (window-resizable-p (selected-window) ncol t)
+                 ;; don't enlarge ignored windows
+                 (> ncol 0))
         (enlarge-window ncol t)))))
 
 (defvar golden-ratio-in-progress nil


### PR DESCRIPTION
* golden-ratio.el (golden-ratio-in-progress): New defvar.
(golden-ratio): Use `golden-ratio-in-progress' instead of turning off
the mode.
(select-window): New defadvice; remove all other stuff.
(golden-ratio-mode): Remove all hooks, the only entry point is
`select-window'.

This change will greatly simplify the life of package writers that have
to work around `golden-ratio-mode'.

Re abo-abo/hydra#64.