### PR TITLE
Fix for the window margins

### DIFF
--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -154,8 +154,9 @@ will prevent the window to be resized to the golden ratio."
 
 (defun golden-ratio--resize-window (dimensions &optional window)
   (with-selected-window (or window (selected-window))
-    (let ((nrow  (floor (- (first  dimensions) (window-height))))
-          (ncol  (floor (- (second dimensions) (window-width)))))
+    (let* ((m (window-margins))
+           (nrow  (floor (- (first  dimensions) (window-height))))
+           (ncol  (floor (- (second dimensions) (+ (window-width) (or (car m) 0) (or (cdr m) 0))))))
       (when (and (> nrow golden-ratio-minimal-height-change)
                  (window-resizable-p (selected-window) nrow))
         (enlarge-window nrow))


### PR DESCRIPTION
Some buffer(e.g., magit-log: ...) has the margin, and the return value of `window-width` is not included the margin.
So, sometime, `golden-ratio--resize-window` compute the width wrongly.

To fix the problem I used `window-margins` function. It was included at ver 21.1.
I think safe to use `window-margins` function.

resolve #84