### PR TITLE
Silence byte-compiler

### DIFF
--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -15,7 +15,7 @@
 ;; This file is free software (MIT License)
 
 ;;; Code:
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defconst golden-ratio--value 1.618
   "The golden ratio value itself.")
@@ -140,6 +140,7 @@ will prevent the window to be resized to the golden ratio."
       (member (symbol-name major-mode)
               golden-ratio-exclude-modes)))
 
+(defvar golden-ratio-mode)
 ;;;###autoload
 (defun golden-ratio (&optional arg)
   "Resizes current window to the golden-ratio's size specs."
@@ -151,11 +152,11 @@ will prevent the window to be resized to the golden ratio."
               (member (buffer-name)
                       golden-ratio-exclude-buffer-names)
               (and golden-ratio-exclude-buffer-regexp
-                (loop for r in golden-ratio-exclude-buffer-regexp
-                         thereis (string-match r (buffer-name))))
+                   (cl-loop for r in golden-ratio-exclude-buffer-regexp
+                            thereis (string-match r (buffer-name))))
               (and golden-ratio-inhibit-functions
-                   (loop for fun in golden-ratio-inhibit-functions
-                         thereis (funcall fun))))
+                   (cl-loop for fun in golden-ratio-inhibit-functions
+                            thereis (funcall fun))))
     (let ((dims (golden-ratio--dimensions))
           (golden-ratio-mode nil))
       ;; Always disable `golden-ratio-mode' to avoid
@@ -180,9 +181,9 @@ will prevent the window to be resized to the golden ratio."
 (defun golden-ratio--post-command-hook ()
   (when (or (memq this-command golden-ratio-extra-commands)
             (and (consp this-command) ; A lambda form.
-                 (loop for com in golden-ratio-extra-commands
-                       thereis (or (member com this-command)
-                                   (member (car-safe com) this-command)))))
+                 (cl-loop for com in golden-ratio-extra-commands
+                          thereis (or (member com this-command)
+                                      (member (car-safe com) this-command)))))
     ;; This is needed in emacs-25 to avoid this error from `recenter':
     ;; `recenter'ing a window that does not display current-buffer.
     ;; This doesn't happen in emacs-24.4 and previous versions.


### PR DESCRIPTION
This fixes some byte-compiler warnings:
```
Compiling file /home/skangas/wip/emacs-packages/golden-ratio/golden-ratio.el at Wed Jan  5 14:31:03 2022
Entering directory ‘/home/skangas/wip/emacs-packages/golden-ratio/’
golden-ratio.el:35:30: Warning: Package cl is deprecated

In golden-ratio:
golden-ratio.el:164:25: Warning: reference to free variable
    ‘golden-ratio-mode’
golden-ratio.el:170:20: Warning: ‘loop’ is an obsolete alias (as of 27.1); use
    ‘cl-loop’ instead.
golden-ratio.el:173:20: Warning: ‘loop’ is an obsolete alias (as of 27.1); use
    ‘cl-loop’ instead.

In golden-ratio--post-command-hook:
golden-ratio.el:199:25: Warning: ‘loop’ is an obsolete alias (as of 27.1); use
    ‘cl-loop’ instead.
```