### PR TITLE
Switch from 'cl' to 'cl-lib' to supress warnings.

### DIFF
--- a/golden-ratio.el
+++ b/golden-ratio.el
@@ -32,7 +32,7 @@
 ;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ;;; Code:
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defconst golden-ratio--value 1.618
   "The golden ratio value itself.")
@@ -154,8 +154,8 @@ will prevent the window to be resized to the golden ratio."
 
 (defun golden-ratio--resize-window (dimensions &optional window)
   (with-selected-window (or window (selected-window))
-    (let ((nrow  (floor (- (first  dimensions) (window-height))))
-          (ncol  (floor (- (second dimensions) (window-width)))))
+    (let ((nrow  (floor (- (cl-first  dimensions) (window-height))))
+          (ncol  (floor (- (cl-second dimensions) (window-width)))))
       (when (and (> nrow golden-ratio-minimal-height-change)
                  (window-resizable-p (selected-window) nrow))
         (enlarge-window nrow))
@@ -180,11 +180,11 @@ will prevent the window to be resized to the golden ratio."
               (member (buffer-name)
                       golden-ratio-exclude-buffer-names)
               (and golden-ratio-exclude-buffer-regexp
-                (loop for r in golden-ratio-exclude-buffer-regexp
+                (cl-loop for r in golden-ratio-exclude-buffer-regexp
                          thereis (string-match r (buffer-name))))
               (and golden-ratio-inhibit-functions
-                   (loop for fun in golden-ratio-inhibit-functions
-                         thereis (funcall fun))))
+                   (cl-loop for fun in golden-ratio-inhibit-functions
+                            thereis (funcall fun))))
     (let ((dims (golden-ratio--dimensions))
           (golden-ratio-mode nil))
       ;; Always disable `golden-ratio-mode' to avoid
@@ -209,9 +209,9 @@ will prevent the window to be resized to the golden ratio."
 (defun golden-ratio--post-command-hook ()
   (when (or (memq this-command golden-ratio-extra-commands)
             (and (consp this-command) ; A lambda form.
-                 (loop for com in golden-ratio-extra-commands
-                       thereis (or (member com this-command)
-                                   (member (car-safe com) this-command)))))
+                 (cl-loop for com in golden-ratio-extra-commands
+                          thereis (or (member com this-command)
+                                      (member (car-safe com) this-command)))))
     ;; This is needed in emacs-25 to avoid this error from `recenter':
     ;; `recenter'ing a window that does not display current-buffer.
     ;; This doesn't happen in emacs-24.4 and previous versions.


### PR DESCRIPTION
Supress several `Warning: ‘loop’ is an obsolete alias (as of 27.1); use ‘cl-loop’ instead.` warning messages. Fixes #87.
* Require `cl-lib` instead of `cl`.
* Replaced all `(loop)` calls by their corresponding `(cl-loop)` counterparts.
* Ditto for `(first)` and `(second)` calls.

@roman: let me know if I'm missing some other functions and I'll be happy to update the PR.